### PR TITLE
Fix start_all.sh to use all compose files

### DIFF
--- a/start_all.sh
+++ b/start_all.sh
@@ -30,9 +30,11 @@ if [ ${#COMPOSE_FILES[@]} -eq 0 ]; then
     exit 0
 fi
 
+compose_args=()
 for file in "${COMPOSE_FILES[@]}"; do
-    dir="$(dirname "$file")"
-    echo "Starting services in $dir"
-    (cd "$dir" && $COMPOSE_CMD up -d)
+    compose_args+=( -f "$file" )
 done
+
+echo "Starting services using compose files:" "${COMPOSE_FILES[@]}"
+$COMPOSE_CMD "${compose_args[@]}" up -d
 


### PR DESCRIPTION
## Summary
- fix `start_all.sh` to start services using all compose files in one command

## Testing
- `./start_all.sh` *(fails: docker compose is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d49d791d483279adbb9b3992032b8