### PR TITLE
Remove invalid device settings for swarm

### DIFF
--- a/ultrafeeder/docker-compose.yml
+++ b/ultrafeeder/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     container_name: ultrafeeder
     hostname: ultrafeeder
     restart: unless-stopped
-    device_cgroup_rules:
-      - 'c 189:* rwm'
     deploy:
       placement:
         constraints:


### PR DESCRIPTION
## Summary
- remove `device_cgroup_rules` from `ultrafeeder` compose file

## Testing
- `bash start_all.sh` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d504878608327ab0e04c2712313c6